### PR TITLE
create boot_archive.hash

### DIFF
--- a/usr/src/cmd/distro_const/utils/boot_archive_archive.py
+++ b/usr/src/cmd/distro_const/utils/boot_archive_archive.py
@@ -57,6 +57,7 @@ from osol_install.ti_defs import TI_ATTR_TARGET_TYPE, \
 # A few commands
 AWK = "/usr/bin/awk"
 CD = "cd"               # Built into the shell
+DIGEST = "/usr/bin/digest"
 CMD7ZA = "/usr/bin/7za"
 CPIO = "/usr/bin/cpio"
 FIND = "/usr/bin/find"
@@ -505,6 +506,14 @@ if not IS_SPARC:
         print "Skipping compression..."
     else:
         print "Doing compression..."
+
+	CMD = DIGEST + " -a sha1 " + BA_ARCHFILE + " > " + BA_ARCHFILE + ".hash"
+        STATUS = os.system(CMD)
+        if (STATUS != 0):
+            raise Exception, (sys.argv[0] +
+                ": digest error on boot archive: " +
+                "digest command returns: " + os.strerror(STATUS >> 8))
+	os.chmod(BA_ARCHFILE + ".hash", 0644)
 
         # archive file using 7zip command and gzip compression
         CMD = CMD7ZA + " a "

--- a/usr/src/cmd/distro_const/utils/post_boot_archive_pkg_image_mod_custom
+++ b/usr/src/cmd/distro_const/utils/post_boot_archive_pkg_image_mod_custom
@@ -84,12 +84,13 @@ initial_cwd=`pwd`
 if [ -d ${PKG_IMG_PATH}/platform ] ; then
     cd ${PKG_IMG_PATH}/platform
     if [ `$UNAME -p` == "sparc" ] ; then
-	$FIND . -type f -a ! -name wanboot -a ! -name boot_archive | \
-	    $XARGS $RM -f
+	$FIND . -type f -a ! -name wanboot -a ! -name boot_archive \
+	    -a ! -name boot_archive.hash | $XARGS $RM -f
         cd ${PKG_IMG_PATH}
 	${LN} -s ../platform boot/platform
     else
-        $FIND . -type f -a ! -name unix -a ! -name boot_archive | $XARGS $RM -f
+        $FIND . -type f -a ! -name unix -a ! -name boot_archive \
+	    -a ! -name boot_archive.hash | $XARGS $RM -f
         # GRUB does not understand symlinks, so make copies
         cd ${PKG_IMG_PATH}
         ${CP} -r ${PKG_IMG_PATH}/platform ${PKG_IMG_PATH}/boot


### PR DESCRIPTION
This update will create archive sha1 hashes for 64 and 32bit, currently for test purposes as full support would need to have grub menu entry update as well. However, i think the grub menu update would be better to implement as separate commit, and also I don't currently have test setup with grub to test it - only tested this with loader, but hash creation itself is not really depending on actual boot loader in any way.
