### PR TITLE
update usbgen to create full usb image

### DIFF
--- a/usr/src/cmd/install-tools/usbgen
+++ b/usr/src/cmd/install-tools/usbgen
@@ -248,6 +248,9 @@ float      usb_size # need floating-point for the calculations below
 typeset isodev
 typeset devs
 typeset rdevs
+typeset s0devs
+typeset rs0devs
+typeset rs2devs
 
 #
 # Confirm input arguments.
@@ -300,12 +303,13 @@ mount -F hsfs "${isodev}" "${iso_path}" || \
 # Compute the size for the new USB image.
 # Use ISO file size + 20% to account for smaller block size on UFS
 # and the log. Round to nearest kbyte plus 512
+# plus 4MB for MBR+SMI label
 #
 get_filesize "usb_size" "${iso_file}"
 if (( usb_size == -1 )) ; then
 	error_handler "Failed to get size of file ${iso_file}"
 fi
-(( usb_size=(int( (usb_size * 1.2) / 1024.) * 1024.) + 512 )) 
+(( usb_size=((int( (usb_size * 1.2) / 1024.) * 1024.) + 512) + 4194304 ))
 
 #
 # Create and mount an empty new USB image.
@@ -313,26 +317,59 @@ fi
 mkfile -n ${usb_size} "${usb_file}" || \
     error_handler "Failed to create file ${usb_file}"
 
-devs="$(lofiadm -a "${usb_file}")" || \
+devs="$(lofiadm -la "${usb_file}")" || \
 	error_handler "Failed to lofiadm file ${usb_file}"
 
 #
-# Set rdevs by replacing lofi with rlofi in devs
+# Set rdevs by replacing dsk with rdsk in devs
 #
-rdevs="${devs/lofi/rlofi}"
+rdevs="${devs/dsk/rdsk}"
+# for mount
+s0devs="${devs/p0/s0}"
+# for newfs and installgrub
+rs0devs="${rdevs/p0/s0}"
+# for prtvtoc | fmthard
+rs2devs="${rdevs/p0/s2}"
+
+#
+# create Solaris2 partition
+#
+fdisk -B "${rdevs}"
+prtvtoc "${rs2devs}" | nawk '
+/^[^\*]/ { r = $1; for(n = 1; n <= NF; n++) vtoc[r,n] = $n }
+END {
+vtoc[0,1] = 0;
+vtoc[0,2] = 2;
+vtoc[0,3] = 00;
+vtoc[0,4] = vtoc[8,6] + 1;
+vtoc[0,5] = vtoc[2,6] - vtoc[8,6];
+vtoc[0,6] = vtoc[2,6];
+printf("\t%d\t%d\t%02d\t%d\t%d\t%d\n",
+	vtoc[0,1], vtoc[0,2], vtoc[0,3], vtoc[0,4], vtoc[0,5], vtoc[0,6]);
+printf("\t%d\t%d\t%02d\t%d\t%d\t%d\n",
+	vtoc[2,1], vtoc[2,2], vtoc[2,3], vtoc[2,4], vtoc[2,5], vtoc[2,6]);
+printf("\t%d\t%d\t%02d\t%d\t%d\t%d\n",
+	vtoc[8,1], vtoc[8,2], vtoc[8,3], vtoc[8,4], vtoc[8,5], vtoc[8,6]);
+}' | fmthard -s- "${rs2devs}"
 
 # newfs doesn't ask questions if stdin isn't a tty.
-newfs "${rdevs}" </dev/null || \
-	error_handler "Failed to construct the UFS file system ${rdevs}"
+newfs "${rs0devs}" </dev/null || \
+	error_handler "Failed to construct the UFS file system ${rs0devs}"
 
-mount -o nologging "${devs}" "${usb_path}" || \
-	error_handler "Failed to mount construct the UFS file system ${rdevs}"
+mount -o nologging "${s0devs}" "${usb_path}" || \
+	error_handler "Failed to mount construct the UFS file system ${rs0devs}"
 
 #
 # Copy the contents of the ISO file to the new USB image.
 #
 print "Copying ISO contents to USB image..."
 (cd "${iso_path}"; find . -print | cpio -pmudV "${usb_path}")
+
+#
+# install bootblocks
+#
+installgrub -mf "${usb_path}/boot/grub/stage1" "${usb_path}/boot/grub/stage2" \
+	"${rs0devs}"
 
 # If we get an error hereforth in menu.lst modifications, proceed with a warning
 trap "" ERR INT


### PR DESCRIPTION
This patch updates usbgen to use labeled lofi device to create full usb image without need to have separate header file.

Note: when used in local zone, the zone config must have device mapping entries to allow access for corresponding /dev/dsk and /dev/rdsk devices and allow mounting ufs file system.
