### PR TITLE
8178 set mode 0555 to usr/sbin/iotrace

### DIFF
--- a/usr/src/pkg/manifests/system-install-media-internal.mf
+++ b/usr/src/pkg/manifests/system-install-media-internal.mf
@@ -88,7 +88,7 @@ file path=sbin/listcd mode=0555
 file path=sbin/listusb mode=0555
 $(i386_ONLY)file path=sbin/mkmenu mode=0555 variant.arch=i386
 file path=usr/lib/install/live_img_pkg5_prep mode=0555
-file path=usr/sbin/iotrace
+file path=usr/sbin/iotrace mode=0555
 file path=usr/sbin/set_lang mode=0555
 license cr_Sun license=cr_Sun
 user username=jack uid=65432 group=staff gcos-field="Default User" home-dir=/jack \


### PR DESCRIPTION
`usr/sbin/iotrace` is a shell script and can't be executed w/o
executable bit.