### PR TITLE
distro_const: properly tag efi platform

### DIFF
--- a/usr/src/cmd/distro_const/utils/create_iso
+++ b/usr/src/cmd/distro_const/utils/create_iso
@@ -130,6 +130,7 @@ if [[ "${PLATFORM}" == "i86pc" ]] ; then
 	    "$VOLSETID" -V "$DISTRO_NAME" \
 	    -eltorito-boot boot/cdboot -no-emul-boot -boot-info-table \
 	    -eltorito-alt-boot \
+	    -eltorito-platform efi \
 	    -eltorito-boot boot/efiboot.img -no-emul-boot \
 	    "$PKG_IMG_PATH"
 else


### PR DESCRIPTION
ET info:
Image in /rpool/dc/media/OpenIndiana_Text_X86.iso
Default entry
        System i386
        Start LBA 166 (0xa6), sector count 4 (0x4)
        Media type: no emulation

Section header: efi, final
        Section entry
                System i386
                Start LBA 167 (0xa7), sector count 8800 (0x2260)
                Media type: no emulation
