### PR TITLE
Fix SPARC text install template because package update of certs package

### DIFF
--- a/usr/src/cmd/distro_const/text_install/text_mode_sparc.xml
+++ b/usr/src/cmd/distro_const/text_install/text_mode_sparc.xml
@@ -440,7 +440,6 @@
 			<base_include type="file" fiocompress="false">etc/path_to_inst</base_include>
 			<base_include type="file" fiocompress="false">etc/default/init</base_include>
 			<base_include type="file" fiocompress="false">etc/nsswitch.conf</base_include>
-			<base_include type="file" fiocompress="false">etc/certs/CA/NetLock_Arany_(Class_Gold)_Fotanusitvany.pem</base_include>
 		</boot_archive_contents>
 	</img_params>
 	<key_value_pairs/>


### PR DESCRIPTION
If you do want to create a new ISO you'll see this error messages without this patch:
/usr/share/distro_const/boot_archive_archive.py: Couldn't stat ./etc/certs/CA/NetLock_Arany_(Class_Gold)_Fotanusitvany.pem to mark as uncompressed in boot_archive: No such file or directory
Traceback (most recent call last):
  File "/usr/share/distro_const/boot_archive_archive.py", line 445, in <module>
    compress(BA_BUILD, BA_LOFI_MNT_PT)
  File "/usr/share/distro_const/boot_archive_archive.py", line 144, in compress
    raise Exception(sys.argv[0] + ": Error building "
Exception: /usr/share/distro_const/boot_archive_archive.py: Error building list of uncompressed boot_archive files.
Child returned err 1
Build completed Mon Dec 13 19:56:26 2021
Build failed.
