### PR TITLE
16411 OI USB installer broken

### DIFF
--- a/usr/src/cmd/slim-install/svc/live-fs-root-minimal
+++ b/usr/src/cmd/slim-install/svc/live-fs-root-minimal
@@ -62,6 +62,12 @@ else
 fi
 
 #
+# Build device tree to make sure we do have device nodes
+# to mount install image.
+echo 'Configuring devices.' > /dev/msglog 2>&1
+/usr/sbin/devfsadm >/dev/msglog 2>&1
+
+#
 # Workaround for devfs lazy init. The sd nodes are not
 # created till you try to access them.
 #


### PR DESCRIPTION
https://www.illumos.org/issues/16411

The problem is that oi does not build device tree before we attempt to mount install image, but not all device nodes are present (however, the drivers should be present in loaded boot archive mounted as miniroot). 