### PR TITLE
Disable GNOME cache services for textinstall installations.

### DIFF
--- a/usr/src/cmd/distro_const/text_install/text_live.xml
+++ b/usr/src/cmd/distro_const/text_install/text_live.xml
@@ -104,6 +104,43 @@
   <service name='system/ca-certificates' version='1' type='service'>
     <instance name='default' enabled='false' />
   </service>
+  <service name='application/cups/scheduler' version='1' type='service'>
+    <instance name='default' enabled='false' />
+  </service>
+  <service name='network/ipfilter' version='1' type='service'>
+    <instance name='default' enabled='false' />
+  </service>
+
+  <!--
+      Make sure GNOME cache services for the text image are all disabled.
+  -->
+  <service name='application/desktop-cache/desktop-mime-cache' version='1' type='service'>
+    <instance name='default' enabled='false' />
+  </service>
+
+  <service name='application/desktop-cache/gconf-cache' version='1' type='service'>
+    <instance name='default' enabled='false' />
+  </service>
+
+  <service name='application/desktop-cache/gio-module-cache' version='1' type='service'>
+    <instance name='default' enabled='false' />
+  </service>
+
+  <service name='application/desktop-cache/icon-cache' version='1' type='service'>
+    <instance name='default' enabled='false' />
+  </service>
+
+  <service name='application/desktop-cache/input-method-cache' version='1' type='service'>
+    <instance name='default' enabled='false' />
+  </service>
+
+  <service name='application/desktop-cache/mime-types-cache' version='1' type='service'>
+    <instance name='default' enabled='false' />
+  </service>
+
+  <service name='application/desktop-cache/pixbuf-loaders-installer' version='1' type='service'>
+    <instance name='default' enabled='false' />
+  </service>
 
   <!--
 	Text mode menu


### PR DESCRIPTION
This also fixes trouble with system/ca-certificates having dependency to cups/print, disabling ipfilter for installs also fixes the troube using nwam at installation time. A complete install using this new config has just been started using a new ISO, without having any issues in the output of: svcs -xv.