### PR TITLE
ignore additional warning since #94

### DIFF
--- a/usr/src/tools/env/nightly
+++ b/usr/src/tools/env/nightly
@@ -224,6 +224,7 @@ function build {
 		| egrep -v "parameter <PSTAMP> set to" \
 		| egrep -v "Ignoring unknown host" \
 		| egrep -v "redefining segment flags attribute for" \
+		| egrep -v "Message contains an embedded URL" \
 		| tee $TMPDIR/build_warnings${SUFFIX} >> $mail_msg_file
 	if [[ -s $TMPDIR/build_warnings${SUFFIX} ]]; then
 		build_ok=n


### PR DESCRIPTION
Since #94  is merged we see a new warning which lets fail the build:

nightly.log:text_install.py:263: warning: Message contains an embedded URL.  Better move it out of the translatable string, see https://www.gnu.org/software/gettext/manual/html_node/No-embedded-URLs.html