### PR TITLE
gui-install: use cXtXd0 for whole disk install

### DIFF
--- a/usr/src/lib/liborchestrator/perform_slim_install.c
+++ b/usr/src/lib/liborchestrator/perform_slim_install.c
@@ -1236,7 +1236,7 @@ do_ti(void *args)
 	 * Create ZFS root pool.
 	 */
 
-	om_log_print("Set zfs root pool device\n");
+	om_log_print("Set zfs root pool device %s\n", disk_name);
 
 	if (prepare_zfs_root_pool_attrs(&ti_ex_attrs, disk_name,
 	    install_slice_id) != OM_SUCCESS) {
@@ -2264,7 +2264,12 @@ prepare_zfs_root_pool_attrs(nvlist_t **attrs, char *disk_name, uint8_t slice_id)
 		return (OM_FAILURE);
 	}
 
-	snprintf(zfs_device, sizeof (zfs_device), "%ss%d", disk_name, slice_id);
+	if (whole_disk != 0) {
+		om_log_print("EFI boot requires whole disk layout, slice %d could not be used . \n", slice_id);
+		snprintf(zfs_device, sizeof (zfs_device), "%s", disk_name);
+	} else {
+		snprintf(zfs_device, sizeof (zfs_device), "%ss%d", disk_name, slice_id);
+	}
 
 	if (nvlist_add_string(*attrs, TI_ATTR_ZFS_RPOOL_DEVICE,
 	    zfs_device) != 0) {

--- a/usr/src/lib/libti/ti_zfm.c
+++ b/usr/src/lib/libti/ti_zfm.c
@@ -416,10 +416,15 @@ zfm_create_pool(nvlist_t *attrs)
 	    "zfs: ZFS pool <%s> will be created on slice <%s>\n",
 	    zfs_pool_name, zfs_device);
 
-	(void) snprintf(cmd, sizeof (cmd),
-	    "/usr/sbin/zpool create -f %s %s",
-	    zfs_pool_name, zfs_device);
-
+	if ((strlen(zfs_device) - strcspn(zfs_device, "d0")) == 2) {
+		(void) snprintf(cmd, sizeof (cmd),
+		    "/usr/sbin/zpool create -f -B %s %s",
+		    zfs_pool_name, zfs_device);
+	} else {
+		(void) snprintf(cmd, sizeof (cmd),
+		    "/usr/sbin/zpool create -f %s %s",
+		    zfs_pool_name, zfs_device);
+	}
 	if (zfm_system(cmd) == -1) {
 		zfm_debug_print(LS_DBGLVL_ERR, "zfs: "
 		    "Couldn't create ZFS pool\n");


### PR DESCRIPTION
With this change the new OE is installed in an rpool on cXtXd0 instead of cXtXd0sY. This is necessary to get loader and EFI boot to work. Regardless of the fact that whole disk pools are recommended.
Install on partitioned disk is unchanged.